### PR TITLE
Corrected capitalization of Quick Claw activation

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -781,7 +781,7 @@ export class BypassSpeedChanceModifier extends PokemonHeldItemModifier {
       const hasQuickClaw = this.type instanceof ModifierTypes.PokemonHeldItemModifierType && this.type.id === "QUICK_CLAW";
 
       if (isCommandFight && hasQuickClaw) {
-        pokemon.scene.queueMessage(getPokemonMessage(pokemon, " used its quick claw to move faster!"));
+        pokemon.scene.queueMessage(getPokemonMessage(pokemon, " used its Quick Claw to move faster!"));
       }
       return true;
     }


### PR DESCRIPTION
## What are the changes?
Made Quick Claw's activation text have capitalization that is consistent with other items' activation texts.